### PR TITLE
Expandindo a cobertura dos testes de Error Handling.

### DIFF
--- a/Test/Fixtures/ErrorHandling/inadequate_continue_on_error.yml
+++ b/Test/Fixtures/ErrorHandling/inadequate_continue_on_error.yml
@@ -1,0 +1,9 @@
+name: Inadequate Continue
+on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Critical Step
+        run: ./deploy.sh

--- a/Test/Fixtures/ErrorHandling/missing_output_validation.yml
+++ b/Test/Fixtures/ErrorHandling/missing_output_validation.yml
@@ -1,0 +1,10 @@
+name: Output Validation
+on: push
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    steps:
+      - id: set_val
+        run: echo "result=fail" >> $GITHUB_OUTPUT
+      - name: Use Output
+        run: echo ${{ steps.set_val.outputs.result }}

--- a/Test/Fixtures/ErrorHandling/no_retry_logic.yml
+++ b/Test/Fixtures/ErrorHandling/no_retry_logic.yml
@@ -1,0 +1,8 @@
+name: No Retry
+on: push
+jobs:
+  network:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Data
+        run: curl https://api.exemplo.com/large-file

--- a/Test/Fixtures/ErrorHandling/steps_no_error_handling.yml
+++ b/Test/Fixtures/ErrorHandling/steps_no_error_handling.yml
@@ -1,0 +1,8 @@
+name: No Error Handling
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Raw Command
+        run: npm install

--- a/Test/Fixtures/ErrorHandling/timeout_checks.yml
+++ b/Test/Fixtures/ErrorHandling/timeout_checks.yml
@@ -1,0 +1,21 @@
+name: Timeout Checks
+on: push
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    strategy:
+      fail-fast: true
+    steps:
+      - name: step1
+        run: exit 1
+        timeout-minutes: 1
+
+  job2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: step2
+        run: sleep 1
+        timeout-minutes: 20

--- a/Test/README.md
+++ b/Test/README.md
@@ -1,0 +1,94 @@
+# Testes de Segurança *Error Handling*
+
+Esta parte do projeto contém **fixtures e testes automatizados** destinados a identificar **más práticas de segurança e manutenção** em *pushes* de códigos no GASH. Cada fixture representa um cenário específico que deve ser detectado pelo *checker*.
+
+---
+
+## Estrutura dos Testes
+
+Cada teste segue o mesmo padrão:
+1. Carrega um arquivo `.yml` representando um workflow
+2. Executa uma verificação específica ou genérica
+3. Avalia se o comportamento esperado foi identificado
+
+---
+
+## Fixtures Documentadas
+
+### 1) `steps_no_error_handling.yml`
+**Teste:** `Test/Fixtures/ErrorHandling/steps_no_error_handling.yml`
+
+**O que testa:**  
+Detecta **fluxos de trabalho** que executam comandos CRÍTICOS **sem qualquer tratamento explícito de erro prévio**.
+
+**Problema identificado:**  
+*Lack of Error Handling* — comandos podem falhar silenciosamente ou causar comportamento inesperado no pipeline.
+
+**Risco:**  
+- Builds quebradas  
+- Estados inconsistentes  
+- Comprometimento da integridade do processo  
+
+---
+
+### 2) `inadequate_continue_on_error.yml`
+**Teste:** `Test/Fixtures/ErrorHandling/inadequate_continue_on_error.yml`
+
+**O que testa:**  
+Identifica o uso **inadequado** de `continue-on-error: true` em jobs ou etapas críticas. Em geral, permanecer com o código funcionando, mesmo a custo de um erro crítico aceito, pode custar muito para a segurança de qualquer projeto - seja privado, seja de fonte aberta.
+
+**Problema identificado:**  
+*Inadequate Continue on Error* — falhas graves são ignoradas e o pipeline continua como se tivesse sucesso.
+
+**Risco:**  
+- Deploys incompletos  
+- Falsa sensação de sucesso  
+- Sistemas em estado inconsistente  
+
+---
+
+### 3) `missing_output_validation.yml`
+**Teste:** `Test/Fixtures/ErrorHandling/missing_output_validation.yml`
+
+**O que testa:**  
+Verifica fluxos de trabalho que utilizam **outputs de comandos/passos dados anteriormente, e que são repassados para outros processos sem validação prévia**.
+
+**Problema identificado:**  
+*Missing Output Validation* — valores derivados de outros steps são reutilizados sem checagem de conteúdo ou formato.
+
+**Risco:**  
+- Falhas lógicas  
+- Execução de fluxos incorretos  
+- Possível comportamento inesperado  
+
+---
+
+### 4) `no_retry_logic.yml`
+**Teste:** `Test/Fixtures/ErrorHandling/no_retry_logic.yml`
+
+**O que testa:**  
+Detecta operações suscetíveis a falhas temporárias (ex.: rede, APIs) **sem lógica de retry**. Isto significa que um processo pode ser interrompido por um erro imprevisível e momentâneo (instabilidade na rede, por exemplo) e mesmo assim não tornará a uma nova tentativa para ser testado.
+
+**Problema identificado:**  
+*No Retry Logic* — o pipeline falha na primeira tentativa, mesmo em erros transitórios.
+
+**Risco:**  
+- Instabilidade do CI/CD  
+- Falhas intermitentes difíceis de diagnosticar  
+- Baixa resiliência do processo  
+
+---
+
+## Objetivo dos Testes
+
+Esses testes garantem que o *checker*:
+
+- Reconheça padrões inseguros em workflows
+- Retorne resultados consistentes
+- Ajude a prevenir falhas de segurança e manutenção em CI/CD
+
+---
+
+## Observação Final
+
+Nem todos os testes exigem a detecção obrigatória de vulnerabilidades; alguns validam apenas que o *checker* **analisa corretamente o cenário** e retorna resultados estruturados.

--- a/Test/Scripts/Smells/ErrorHandlingExpansion.py
+++ b/Test/Scripts/Smells/ErrorHandlingExpansion.py
@@ -6,8 +6,6 @@ from Analysis.Smells.Categories.Maintenance.ErrorHandling.ErrorHandlingSt import
 def load_data(filename):
     base_path = os.path.dirname(os.path.abspath(__file__))
     file_path = os.path.join(base_path, '..', '..', 'Fixtures', 'ErrorHandling', filename)
-    # Se o ActionParser estiver falhando porque o arquivo não é um workflow completo,
-    # você pode carregar o YAML puro aqui, mas vamos tentar via ActionParser primeiro:
     action = Action(file_path=file_path)
     return action.prepare_for_analysis()
 
@@ -34,3 +32,13 @@ def test_expansion_retry_logic(checker):
     data = load_data('no_retry_logic.yml')
     findings = checker.check(data)
     assert isinstance(findings, list)
+    
+def test_expansion_fail_fast(checker):
+    data = load_data('timeout_checks.yml')
+    findings = checker.check_fail_fast(data)
+    assert len(findings) > 0
+
+def test_expansion_job_timeouts(checker):
+    data = load_data('timeout_checks.yml')
+    findings = checker.check_timeouts(data)
+    assert len(findings) > 0

--- a/Test/Scripts/Smells/ErrorHandlingExpansion.py
+++ b/Test/Scripts/Smells/ErrorHandlingExpansion.py
@@ -1,0 +1,36 @@
+import pytest
+import os
+from Analysis.Parse.ActionParser import Action
+from Analysis.Smells.Categories.Maintenance.ErrorHandling.ErrorHandlingSt import MainErrorHandlingCheck
+
+def load_data(filename):
+    base_path = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_path, '..', '..', 'Fixtures', 'ErrorHandling', filename)
+    # Se o ActionParser estiver falhando porque o arquivo não é um workflow completo,
+    # você pode carregar o YAML puro aqui, mas vamos tentar via ActionParser primeiro:
+    action = Action(file_path=file_path)
+    return action.prepare_for_analysis()
+
+@pytest.fixture
+def checker():
+    return MainErrorHandlingCheck()
+
+def test_expansion_steps_no_error_handling(checker):
+    data = load_data('steps_no_error_handling.yml')
+    findings = checker.check(data)
+    assert len(findings) > 0
+
+def test_expansion_continue_on_error(checker):
+    data = load_data('inadequate_continue_on_error.yml')
+    findings = checker.check_continue_on_error(data)
+    assert len(findings) > 0
+
+def test_expansion_output_validation(checker):
+    data = load_data('missing_output_validation.yml')
+    findings = checker.check(data)
+    assert isinstance(findings, list)
+
+def test_expansion_retry_logic(checker):
+    data = load_data('no_retry_logic.yml')
+    findings = checker.check(data)
+    assert isinstance(findings, list)


### PR DESCRIPTION
## Expansão de Testes: Error Handling (#24)

Este PR introduz novos casos de teste para o detector de **Error Handling Smells**, aumentando a cobertura de código do arquivo `ErrorHandlingSt.py`.

### Alterações Realizadas
- **Novo Script de Teste**: Criado o arquivo `Test/Scripts/Smells/ErrorHandlingExpansion.py` utilizando o framework `pytest`.
- **Criação de Fixtures**: Adição de 4 novos arquivos YAML em `Test/Fixtures/ErrorHandling/` para simular diferentes cenários de infraestrutura:
  1. `steps_no_error_handling.yml`: Validação de erros em nível de step.
  2. `inadequate_continue_on_error.yml`: Uso indevido da flag `continue-on-error`.
  3. `missing_output_validation.yml`: Verificação de lógica de saída para tratamento de falhas.
  4. `no_retry_logic.yml`: Implementação de estratégias de retentativa (retry).

### Como executar os testes
```powershell
# Executar os testes específicos
python -m pytest Test/Scripts/Smells/ErrorHandlingExpansion.py